### PR TITLE
Update Update scalikejdbc-mapper-generator version.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers ++= Seq(
 libraryDependencies += "com.h2database" % "h2" % "1.4.191"
 
 addSbtPlugin("org.scalariform"   % "sbt-scalariform"              % "1.6.0")
-addSbtPlugin("org.scalikejdbc"   % "scalikejdbc-mapper-generator" % "2.4.2")
+addSbtPlugin("org.scalikejdbc"   % "scalikejdbc-mapper-generator" % "2.5.2")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"                   % "2.5.4")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-coffeescript"             % "1.0.0")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"                  % "0.1.10")


### PR DESCRIPTION
#11. 

It was caused by a mixture of plug-ins of multiple versions.
`scalikejdbc-play-fixture` depends on scalikeJDBC `2.5.2` .
But, `scalikejdbc-mapper-generator` depends on `2.4.2`.

- [errorlog.txt](https://gist.github.com/SAMMY7th/6d3fad0451d87de16a1caac90a1e5cd3)

Update `scalike-jdbc-mapper` version `2.4.2` to `2.5.2`.